### PR TITLE
Update project to .NET 9.0 and add OpenAPI support

### DIFF
--- a/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
+++ b/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
@@ -6,7 +6,7 @@ namespace MDev.Dotnet.AspNetCore.Apis.Extensions;
 
 public static class OpenApiExtensions
 {
-    public static IHostApplicationBuilder RegisterOpenApi<T>(this IHostApplicationBuilder builder,
+    public static IHostApplicationBuilder RegisterOpenApi(this IHostApplicationBuilder builder,
                                                                 bool forceHttpsServers = false)
     {
         builder.Services.AddOpenApi(options => {

--- a/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
+++ b/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
@@ -1,0 +1,27 @@
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MDev.Dotnet.AspNetCore.Apis.Extensions;
+
+public static class OpenApiExtensions
+{
+    public static IHostApplicationBuilder RegisterOpenApi<T>(this IHostApplicationBuilder builder,
+                                                                bool forceHttpsServers = false)
+    {
+        builder.Services.AddOpenApi(options => {
+            if (forceHttpsServers)
+            {
+                options.AddDocumentTransformer((document, context, cancellationToken) => {
+                    foreach (var server in document.Servers)
+                    {
+                        server.Url = server.Url.Replace("http://", "https://");
+                    }
+                    return Task.CompletedTask;
+                });
+            }
+        });
+
+        return builder;
+    }
+}

--- a/src/MDev.Dotnet.AspNetCore/MDev.Dotnet.AspNetCore.csproj
+++ b/src/MDev.Dotnet.AspNetCore/MDev.Dotnet.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	  <Authors>MACK Mathieu</Authors>
@@ -37,17 +37,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="9.0.4" />
+	<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson">
-      <Version>9.0.4</Version>
-    </PackageReference>
-  </ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson">
-			<Version>8.0.11</Version>
-		</PackageReference>
-	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
Modified `MDev.Dotnet.AspNetCore.csproj` to target only .NET 9.0, removing support for .NET 8.0. Added package references for `Microsoft.AspNetCore.Mvc.NewtonsoftJson` and `Microsoft.AspNetCore.OpenApi` (version 9.0.4). Removed conditional item groups for package management simplification.

Introduced `OpenApiExtensions` class with `RegisterOpenApi<T>` method to facilitate OpenAPI service registration and enable HTTP to HTTPS URL transformation for enhanced security.

Resolves #32