### PR TITLE
Add RequireDaprApiTokenAttribute for API token validation

### DIFF
--- a/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
+++ b/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
@@ -7,24 +7,10 @@ namespace MDev.Dotnet.AspNetCore.Apis.Extensions;
 public static class OpenApiExtensions
 {
     public static IHostApplicationBuilder RegisterOpenApi(this IHostApplicationBuilder builder,
-                                                                bool includeServerUrls = true,
-                                                                bool forceHttpsServers = false)
+                                                                bool forceHttpsServers = false,
+                                                                bool includeServerUrls = true)
     {
         builder.Services.AddOpenApi(options => {
-            if (!includeServerUrls)
-            {
-                options.AddDocumentTransformer((document, context, cancellationToken) => {
-                    if (document.Servers is null || !document.Servers.Any())
-                    {
-                        return Task.CompletedTask;
-                    }
-                    
-                    document.Servers.Clear();
-
-                    return Task.CompletedTask;
-                });
-            }
-            
             if (forceHttpsServers)
             {
                 options.AddDocumentTransformer((document, context, cancellationToken) => {
@@ -41,6 +27,19 @@ public static class OpenApiExtensions
                 });
             }
 
+            if (!includeServerUrls)
+            {
+                options.AddDocumentTransformer((document, context, cancellationToken) => {
+                    if (document.Servers is null || !document.Servers.Any())
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    document.Servers.Clear();
+
+                    return Task.CompletedTask;
+                });
+            }
         });
 
         return builder;

--- a/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
+++ b/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
@@ -7,9 +7,18 @@ namespace MDev.Dotnet.AspNetCore.Apis.Extensions;
 public static class OpenApiExtensions
 {
     public static IHostApplicationBuilder RegisterOpenApi(this IHostApplicationBuilder builder,
+                                                                bool includeServerUrls = true,
                                                                 bool forceHttpsServers = false)
     {
         builder.Services.AddOpenApi(options => {
+            if (!includeServerUrls)
+            {
+                options.AddDocumentTransformer((document, context, cancellationToken) => {
+                    document.Servers.Clear();
+                    return Task.CompletedTask;
+                });
+            }
+            
             if (forceHttpsServers)
             {
                 options.AddDocumentTransformer((document, context, cancellationToken) => {
@@ -20,6 +29,7 @@ public static class OpenApiExtensions
                     return Task.CompletedTask;
                 });
             }
+
         });
 
         return builder;

--- a/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
+++ b/src/MDev.Dotnet.AspNetCore/Apis/Extensions/OpenApiExtensions.cs
@@ -14,7 +14,13 @@ public static class OpenApiExtensions
             if (!includeServerUrls)
             {
                 options.AddDocumentTransformer((document, context, cancellationToken) => {
+                    if (document.Servers is null || !document.Servers.Any())
+                    {
+                        return Task.CompletedTask;
+                    }
+                    
                     document.Servers.Clear();
+
                     return Task.CompletedTask;
                 });
             }
@@ -22,6 +28,11 @@ public static class OpenApiExtensions
             if (forceHttpsServers)
             {
                 options.AddDocumentTransformer((document, context, cancellationToken) => {
+                    if(document.Servers is null || !document.Servers.Any())
+                    {
+                        return Task.CompletedTask;
+                    }
+
                     foreach (var server in document.Servers)
                     {
                         server.Url = server.Url.Replace("http://", "https://");

--- a/src/MDev.Dotnet.AspNetCore/MDev.Dotnet.AspNetCore.csproj
+++ b/src/MDev.Dotnet.AspNetCore/MDev.Dotnet.AspNetCore.csproj
@@ -19,6 +19,12 @@
 	  <RepositoryType>git</RepositoryType>
 	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Exceptions\**" />
+    <EmbeddedResource Remove="Exceptions\**" />
+    <None Remove="Exceptions\**" />
+  </ItemGroup>
 	
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
@@ -27,10 +33,6 @@
 	<ItemGroup>
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
-
-	<ItemGroup>
-    <Folder Include="Exceptions\Extensions\" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />

--- a/src/MDev.Dotnet.Azure.ContainerApps/Dapr/Attributes/RequireDaprApiTokenAttribute.cs
+++ b/src/MDev.Dotnet.Azure.ContainerApps/Dapr/Attributes/RequireDaprApiTokenAttribute.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
+
+namespace MDev.Dotnet.Azure.ContainerApps.Dapr.Attributes;
+
+/// <summary>
+/// Attribute to require the Dapr API token header (DAPR_API_TOKEN) for controller actions.
+/// Returns 401 Unauthorized if the header is missing, empty, or does not match the configured value.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public class RequireDaprApiTokenAttribute : Attribute, IAuthorizationFilter
+{
+    private const string DaprApiTokenHeader = "dapr-api-token";
+    private const string AppApiTokenConfigKey = "APP_API_TOKEN";
+    private static string? _expectedToken;
+    private static bool _initialized = false;
+
+    private static void EnsureTokenLoaded(IServiceProvider services)
+    {
+        if (_initialized) return;
+        var config = services.GetService(typeof(IConfiguration)) as IConfiguration;
+        _expectedToken = config?[AppApiTokenConfigKey];
+        _initialized = true;
+    }
+
+    public void OnAuthorization(AuthorizationFilterContext context)
+    {
+        EnsureTokenLoaded(context.HttpContext.RequestServices);
+        if (string.IsNullOrWhiteSpace(_expectedToken) ||
+            !context.HttpContext.Request.Headers.TryGetValue(DaprApiTokenHeader, out var token) ||
+            !string.Equals(token, _expectedToken, StringComparison.Ordinal))
+        {
+            context.Result = new UnauthorizedResult();
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the `RequireDaprApiTokenAttribute` class, which implements the `IAuthorizationFilter` interface. This attribute enforces the presence of a specific API token in request headers for controller actions in an ASP.NET Core application. If the token is missing, empty, or does not match the expected value from the configuration, a 401 Unauthorized response is returned. The class also includes functionality to load the expected token from the application settings.

Resolves #41