### PR TITLE
Fxes for code scanning alert (Warnings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   dotnet-pr:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: mathieumack/MyGithubActions/actions/buildandtestdotnet@main
@@ -28,6 +30,10 @@ jobs:
           version: '0.0.0'
   dotnet:
     if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     uses: mathieumack/MyGithubActions/.github/workflows/dotnetlib.yml@main
     with:
       sourceDirectoryPath: 'src'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,20 @@ on:
           type: boolean
 
 jobs:
+  dotnet-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mathieumack/MyGithubActions/actions/buildandtestdotnet@main
+        with:
+          workingDirectory: 'src'
+          dotnet-version: |
+            9.0.x
+            10.0.x
+          version: '0.0.0'
   dotnet:
+    if: github.event_name != 'pull_request'
     uses: mathieumack/MyGithubActions/.github/workflows/dotnetlib.yml@main
     with:
       sourceDirectoryPath: 'src'

--- a/src/MDev.Dotnet.Azure.ContainerApps/AsyncOperations/Services/Handlers/AsyncOperationRequestsService.cs
+++ b/src/MDev.Dotnet.Azure.ContainerApps/AsyncOperations/Services/Handlers/AsyncOperationRequestsService.cs
@@ -21,9 +21,13 @@ public class AsyncOperationRequestsService
 
     internal async Task HandleAsync(AsyncOperationRequestMessage item, CancellationToken cancellationToken)
     {
+        var safeOperationName = (item.OperationName ?? string.Empty)
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty);
+
         if(!handlers.Any(e => e.HandlerOperationName.Equals(item.OperationName)))
         {
-            logger.LogInformation("async.operation : No service registered for {operation}", item.OperationName);
+            logger.LogInformation("async.operation : No service registered for {operation}", safeOperationName);
             return;
         }
 

--- a/src/MDev.Dotnet.Azure.ContainerApps/Authentication/Extensions/IHttpContextAccessorExtensions.cs
+++ b/src/MDev.Dotnet.Azure.ContainerApps/Authentication/Extensions/IHttpContextAccessorExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using System.Text.Json;
 using System.Web;
 
@@ -7,6 +8,20 @@ namespace MDev.Dotnet.Azure.ContainerApps.Authentication.Extensions;
 
 public static class IHttpContextAccessorExtensions
 {
+    private static string SanitizeForLog(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var sanitized = value
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty);
+
+        return new string(sanitized.Where(c => !char.IsControl(c) || c == '\t').ToArray());
+    }
+
     public static string GetUserId(this IHttpContextAccessor httpContextAccessor, bool decode = false)
     {
         return httpContextAccessor.GetUserValue("X-MS-CLIENT-PRINCIPAL-ID", decode);
@@ -48,7 +63,9 @@ public static class IHttpContextAccessorExtensions
     {
         foreach (var header in contextAccessor.HttpContext.Request.Headers)
         {
-            logger.LogInformation("{HeaderName}: {HeaderValue}", header.Key, header.Value);
+            var sanitizedHeaderName = SanitizeForLog(header.Key);
+            var sanitizedHeaderValue = SanitizeForLog(header.Value.ToString());
+            logger.LogInformation("{HeaderName}: {HeaderValue}", sanitizedHeaderName, sanitizedHeaderValue);
         }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/mathieumack/MDev.Dotnet/security/code-scanning/7](https://github.com/mathieumack/MDev.Dotnet/security/code-scanning/7)

To fix this without changing behavior, sanitize the user-controlled value before writing it to logs by removing line breaks (and preferably other control characters) from `item.OperationName`. Keep using structured logging, but pass the sanitized value instead of the raw input.

Best targeted fix in the shown code:
- **File:** `src/MDev.Dotnet.Azure.ContainerApps/AsyncOperations/Services/Handlers/AsyncOperationRequestsService.cs`
- **Change region:** inside `HandleAsync`, before the `if (!handlers.Any(...))` check and the log call.
- **Implementation details:**
  - Create a local variable like `safeOperationName`.
  - Handle null safely.
  - Remove `\r` and `\n` via `Replace`.
  - Use `safeOperationName` in the log call on line 26.
  - Keep matching logic and handler invocation unchanged to avoid functional changes.

No other files are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
